### PR TITLE
Fix isUpdating and isDeleting flags when update/delete fails

### DIFF
--- a/src/jsonapi.ts
+++ b/src/jsonapi.ts
@@ -334,7 +334,7 @@ export const reducer = handleActions(
         { type, id },
         IS_UPDATING
       )
-        .set("isUpdating", state.isUpdating + 1)
+        .set("isUpdating", state.isUpdating - 1)
         .value();
     },
 
@@ -364,7 +364,7 @@ export const reducer = handleActions(
         { type, id },
         IS_DELETING
       )
-        .set("isDeleting", state.isDeleting + 1)
+        .set("isDeleting", state.isDeleting - 1)
         .value();
     }
   },

--- a/test/jsonapi.test.ts
+++ b/test/jsonapi.test.ts
@@ -29,6 +29,9 @@ const apiDeleted = createAction("API_DELETED");
 const apiWillUpdate = createAction("API_WILL_UPDATE");
 const apiWillDelete = createAction("API_WILL_DELETE");
 
+const apiUpdateFailed = createAction("API_UPDATE_FAILED");
+const apiDeleteFailed = createAction("API_DELETE_FAILED");
+
 const state = {
   endpoint: {
     host: null,
@@ -880,5 +883,27 @@ describe("Relationships without data key should not be reset", () => {
     expect(updatedState2.articles.data[0].relationships.author).toEqual({
       data: { id: "42", type: "people" }
     });
+  });
+});
+
+describe("progress flags", () => {
+  it("should update isUpdating flag properly when update fails", () => {
+    let updatedState = reducer(state, apiWillUpdate(state.users.data[0]));
+    expect(updatedState.isUpdating).toEqual(1);
+    updatedState = reducer(
+      updatedState,
+      apiUpdateFailed({ resource: state.users.data[0] })
+    );
+    expect(updatedState.isUpdating).toEqual(0);
+  });
+
+  it("should update isDeleting flag properly when delete fails", () => {
+    let updatedState = reducer(state, apiWillDelete(state.users.data[0]));
+    expect(updatedState.isDeleting).toEqual(1);
+    updatedState = reducer(
+      updatedState,
+      apiDeleteFailed({ resource: state.users.data[0] })
+    );
+    expect(updatedState.isDeleting).toEqual(0);
   });
 });


### PR DESCRIPTION
When update or delete fails, isUpdating/isDeleting flags should be decremented but they are incremented.